### PR TITLE
Remove pry dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    s3_backup (0.0.4)
+    s3_backup (0.0.5)
       faker (>= 1.4)
       fog (>= 1.41)
       mime-types (>= 1.25)
@@ -15,12 +15,14 @@ GEM
     builder (3.2.3)
     concurrent-ruby (1.0.5)
     diff-lcs (1.2.5)
-    excon (0.58.0)
+    domain_name (0.5.20170404)
+      unf (>= 0.0.5, < 1.0.0)
+    excon (0.59.0)
     faker (1.8.4)
       i18n (~> 0.5)
     fission (0.5.0)
       CFPropertyList (~> 2.2)
-    fog (1.41.0)
+    fog (1.42.0)
       fog-aliyun (>= 0.1.0)
       fog-atmos
       fog-aws (>= 0.6.0)
@@ -37,6 +39,7 @@ GEM
       fog-json
       fog-local
       fog-openstack
+      fog-ovirt
       fog-powerdns (>= 0.1.1)
       fog-profitbricks
       fog-rackspace
@@ -53,7 +56,7 @@ GEM
       fog-xenserver
       fog-xml (~> 0.1.1)
       ipaddress (~> 0.5)
-      json (>= 1.8, < 2.0)
+      json (~> 2.0)
     fog-aliyun (0.2.0)
       fog-core (~> 1.27)
       fog-json (~> 1.0)
@@ -62,12 +65,12 @@ GEM
     fog-atmos (0.1.0)
       fog-core
       fog-xml
-    fog-aws (1.4.0)
+    fog-aws (1.4.1)
       fog-core (~> 1.38)
       fog-json (~> 1.0)
       fog-xml (~> 0.1)
       ipaddress (~> 0.8)
-    fog-brightbox (0.13.0)
+    fog-brightbox (0.14.0)
       fog-core (~> 1.22)
       fog-json
       inflecto (~> 0.0.2)
@@ -109,17 +112,22 @@ GEM
     fog-json (1.0.2)
       fog-core (~> 1.0)
       multi_json (~> 1.10)
-    fog-local (0.3.1)
+    fog-local (0.4.0)
       fog-core (~> 1.27)
-    fog-openstack (0.1.21)
+    fog-openstack (0.1.22)
       fog-core (>= 1.40)
       fog-json (>= 1.0)
       ipaddress (>= 0.8)
+    fog-ovirt (0.1.1)
+      fog-core (~> 1.45)
+      fog-json
+      fog-xml (~> 0.1.1)
+      rbovirt (~> 0.1.4)
     fog-powerdns (0.1.1)
       fog-core (~> 1.27)
       fog-json (~> 1.0)
       fog-xml (~> 0.1)
-    fog-profitbricks (3.0.0)
+    fog-profitbricks (4.0.0)
       fog-core (~> 1.42)
       fog-json (~> 1.0)
     fog-rackspace (0.1.5)
@@ -156,7 +164,7 @@ GEM
     fog-voxel (0.1.0)
       fog-core
       fog-xml
-    fog-vsphere (1.11.3)
+    fog-vsphere (1.13.1)
       fog-core
       rbvmomi (~> 1.9)
     fog-xenserver (0.3.0)
@@ -166,18 +174,21 @@ GEM
       fog-core
       nokogiri (>= 1.5.11, < 2.0.0)
     formatador (0.2.5)
-    i18n (0.9.0)
+    http-cookie (1.0.3)
+      domain_name (~> 0.5)
+    i18n (0.9.1)
       concurrent-ruby (~> 1.0)
     inflecto (0.0.2)
     ipaddress (0.8.3)
-    json (1.8.6)
+    json (2.1.0)
     mime-types (3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2016.0521)
-    mini_portile2 (2.2.0)
-    multi_json (1.12.1)
-    nokogiri (1.8.0)
-      mini_portile2 (~> 2.2.0)
+    mini_portile2 (2.3.0)
+    multi_json (1.12.2)
+    netrc (0.11.0)
+    nokogiri (1.8.1)
+      mini_portile2 (~> 2.3.0)
     parallel (1.12.0)
     parser (2.4.0.0)
       ast (~> 2.2)
@@ -185,11 +196,18 @@ GEM
     rainbow (2.2.2)
       rake
     rake (11.2.2)
+    rbovirt (0.1.4)
+      nokogiri
+      rest-client (> 1.7.0)
     rbvmomi (1.11.3)
       builder (~> 3.0)
       json (>= 1.8)
       nokogiri (~> 1.5)
       trollop (~> 2.1)
+    rest-client (2.0.2)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 4.0)
+      netrc (~> 0.8)
     rspec (3.5.0)
       rspec-core (~> 3.5.0)
       rspec-expectations (~> 3.5.0)
@@ -212,6 +230,9 @@ GEM
       unicode-display_width (~> 1.0, >= 1.0.1)
     ruby-progressbar (1.8.1)
     trollop (2.1.2)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.7.4)
     unicode-display_width (1.3.0)
     xml-simple (1.1.5)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,7 +13,6 @@ GEM
     CFPropertyList (2.3.5)
     ast (2.3.0)
     builder (3.2.3)
-    coderay (1.1.1)
     concurrent-ruby (1.0.5)
     diff-lcs (1.2.5)
     excon (0.58.0)
@@ -172,7 +171,6 @@ GEM
     inflecto (0.0.2)
     ipaddress (0.8.3)
     json (1.8.6)
-    method_source (0.8.2)
     mime-types (3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2016.0521)
@@ -184,10 +182,6 @@ GEM
     parser (2.4.0.0)
       ast (~> 2.2)
     powerpack (0.1.1)
-    pry (0.10.4)
-      coderay (~> 1.1.0)
-      method_source (~> 0.8.1)
-      slop (~> 3.4)
     rainbow (2.2.2)
       rake
     rake (11.2.2)
@@ -217,7 +211,6 @@ GEM
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.0, >= 1.0.1)
     ruby-progressbar (1.8.1)
-    slop (3.6.0)
     trollop (2.1.2)
     unicode-display_width (1.3.0)
     xml-simple (1.1.5)
@@ -226,10 +219,9 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  pry (~> 0.10)
   rspec (~> 3.0)
   rubocop (~> 0.49)
   s3_backup!
 
 BUNDLED WITH
-   1.14.6
+   1.16.0

--- a/lib/s3_backup/config.rb
+++ b/lib/s3_backup/config.rb
@@ -1,7 +1,3 @@
-# rubocop:disable Style/RescueModifier
-require 'pry' rescue nil
-# rubocop:enable Style/RescueModifier
-
 require 'erb'
 require 'yaml'
 require 'English'

--- a/lib/s3_backup/version.rb
+++ b/lib/s3_backup/version.rb
@@ -1,3 +1,3 @@
 module S3Backup # :nodoc:
-  VERSION = '0.0.4'.freeze
+  VERSION = '0.0.5'.freeze
 end

--- a/s3_backup.gemspec
+++ b/s3_backup.gemspec
@@ -22,7 +22,6 @@ Gem::Specification.new do |s|
   s.add_dependency 'ruby-progressbar', '~> 1.8'
   s.add_dependency 'mime-types', '>= 1.25'
 
-  s.add_development_dependency 'pry', '~> 0.10'
   s.add_development_dependency 'rspec', '~> 3.0'
   s.add_development_dependency 'rubocop', '~> 0.49'
 end


### PR DESCRIPTION
The exception thrown when pry is missing isn't caught correctly at the moment. But it's not needed anyway, so just remove.