### PR TITLE
Handle negative remaining (inexact numbers)

### DIFF
--- a/lib/s3_backup/storage/s3.rb
+++ b/lib/s3_backup/storage/s3.rb
@@ -84,6 +84,11 @@ module S3Backup
       end
 
       def update_progress_bar(total, remaining)
+        # Somehow remaining can be negative so we handle this by force it to
+        # be zero in this scenario. Without this, progress_bar.progress
+        # will throw an exception.
+        remaining = 0 if remaining < 0
+
         progress_bar.progress = (((total - remaining) * 100) / total).to_i
       end
 


### PR DESCRIPTION
````
Time: 00:27:39                                                   ᗧ 100% Progress
rake aborted!
ProgressBar::InvalidProgressError: You can't set the item's current value to be greater than the total.
/tmp/.bundle/api-sandbox-db-backup/ruby/2.2.0/gems/ruby-progressbar-1.9.0/lib/ruby-progressbar/progress.rb:63:in `progress='
/tmp/.bundle/api-sandbox-db-backup/ruby/2.2.0/gems/ruby-progressbar-1.9.0/lib/ruby-progressbar/base.rb:178:in `block in update_progress'
/tmp/.bundle/api-sandbox-db-backup/ruby/2.2.0/gems/ruby-progressbar-1.9.0/lib/ruby-progressbar/output.rb:43:in `with_refresh'
/tmp/.bundle/api-sandbox-db-backup/ruby/2.2.0/gems/ruby-progressbar-1.9.0/lib/ruby-progressbar/base.rb:177:in `update_progress'
/tmp/.bundle/api-sandbox-db-backup/ruby/2.2.0/gems/ruby-progressbar-1.9.0/lib/ruby-progressbar/base.rb:97:in `progress='
/tmp/.bundle/api-sandbox-db-backup/ruby/2.2.0/gems/s3_backup-0.0.6/lib/s3_backup/storage/s3.rb:87:in `update_progress_bar'
/tmp/.bundle/api-sandbox-db-backup/ruby/2.2.0/gems/s3_backup-0.0.6/lib/s3_backup/storage/s3.rb:49:in `block in download!'
````